### PR TITLE
Dynamically creating types for dynamically compiled lambdas

### DIFF
--- a/src/test/java/pl/joegreen/lambdaFromString/LambdaFactoryTest.java
+++ b/src/test/java/pl/joegreen/lambdaFromString/LambdaFactoryTest.java
@@ -128,4 +128,22 @@ public class LambdaFactoryTest {
         factory.createLambdaUnchecked("", new TypeReference<Supplier<Object>>() {});
     }
 
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void dynamicIntegerIncrement() {
+        TypeReference<?> type = new TypeReference<Function<Integer, Integer>>() {};
+        Function<Integer, Integer> lambda = (Function<Integer, Integer>)factory.createLambdaUnchecked(
+                "i -> i+1", type.toString());
+        assertTrue(1 == lambda.apply(0));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void dynamicIntegerMultiply(){
+        TypeReference<?> type = new TypeReference<IntBinaryOperator>() {};
+        IntBinaryOperator lambda = (IntBinaryOperator)factory.createLambdaUnchecked(
+                "(a,b) -> a*b", type.toString());
+        assertEquals(1 * 2 * 3 * 4, IntStream.range(1, 5).reduce(lambda).getAsInt());
+    }
 }


### PR DESCRIPTION
Hi Paweł,

Thanks much for making lambdaFromString available. I have a use case for it: providing lambdas on the command-line. Before now, we've been using JRuby for this purpose, but with your library the performance is quite a bit better, and the error checking during compilation is useful. 

The one tweak I needed to make to your library was to allow types to be specified dynamically. Take a look at the pull request and see if you think it's a good approach, or if there might be a better way to dynamically compose your TypeReference objects.

To see how we're using it, checkout:
[https://github.com/leadscope/commanda](https://github.com/leadscope/commanda)

If you decide to build it, you'll also need the ToxML dependency:
[https://github.com/leadscope/toxml-api](https://github.com/leadscope/toxml-api)

Let me know if you have any questions or suggestions -  

Cheers,
Scott